### PR TITLE
Add missing dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
+    install_requires=[
+        'requests',
+    ],
 )


### PR DESCRIPTION
`heartbeat.py` requires the `requests` package.