### PR TITLE
Return Response objects.

### DIFF
--- a/heartbeat_sh/heartbeat.py
+++ b/heartbeat_sh/heartbeat.py
@@ -19,7 +19,7 @@ class HeartbeatClient:
             query += "&" if len(query) > 0 else "?"
             query += f"error={int(error_timeout.total_seconds())}"
 
-        requests.post(f"{self.base_url}beat/{name}{query}")
+        return requests.post(f"{self.base_url}beat/{name}{query}")
 
     def delete_beat(self, name):
-        requests.delete(f"{self.base_url}beat/{name}")
+        return requests.delete(f"{self.base_url}beat/{name}")


### PR DESCRIPTION
Sometimes we need to know whether the heartbeat was sent successfully. Currently, it will fail silently. I am not sure whether `HeartbeatClient` should raise an error when the HTTP transaction was unsucsesful or the response is unsatisfactory, or whether that should be left to the caller. I opted for the latter, more conservative approach in this PR.