### PR TITLE
#4 Dependency Injection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,39 @@
 
 This is a Python client library for [heartbeat.sh](https://heartbeat.sh).
 
-## Usage
+## Quick start
 
-Install with `pip install heartbeat-sh`
+Install with `pip install heartbeat-sh requests`
 
-```Python
+```python
 from datetime import timedelta
 from heartbeat_sh import HeartbeatClient
 
 HeartbeatClient("example").send_beat(
+    "example:python",
+    timedelta(days=1, hours=2),
+    timedelta(days=2)
+)
+```
+
+## Use a custom requests library (Dependency Injection)
+
+By default, this module uses the [`requests`](https://docs.python-requests.org/en/latest/) library to make HTTP 
+requests. This is not a requirement. You may inject any request library:
+
+```python
+from datetime import timedelta
+from heartbeat_sh import HeartbeatClient
+
+def request(url: str, method: str):
+    return {
+        "fake": "json result"
+    }
+
+HeartbeatClient(
+    subdomain="example",
+    request=request,
+).send_beat(
     "example:python",
     timedelta(days=1, hours=2),
     timedelta(days=2)

--- a/heartbeat_sh/heartbeat.py
+++ b/heartbeat_sh/heartbeat.py
@@ -1,21 +1,31 @@
 from datetime import timedelta
+from typing import Any, Protocol
 
-import requests
+
+class RequestCallable(Protocol):
+    def __call__(self, *, method: str, url: str) -> Any:
+        ...
 
 
 class HeartbeatClient:
-    def __init__(self, subdomain: str):
+    def __init__(self, subdomain: str, request: RequestCallable = None):
         self.subdomain = subdomain
+        self.request = request or _default_request
 
         self.proto = "https"
         self.host = "heartbeat.sh"
         self.base_url = f"{self.proto}://{self.subdomain}.{self.host}/"
 
     def get_beats(self):
-        r = requests.get(f"{self.base_url}heartbeats")
-        return r.json()["Heartbeats"]
+        r = self.request(method="GET", url=f"{self.base_url}heartbeats")
+        return r["Heartbeats"]
 
-    def send_beat(self, name: str, warning_timeout: timedelta = None, error_timeout: timedelta = None):
+    def send_beat(
+        self,
+        name: str,
+        warning_timeout: timedelta = None,
+        error_timeout: timedelta = None,
+    ):
         query = ""
         if warning_timeout is not None:
             query += f"?warning={int(warning_timeout.total_seconds())}"
@@ -23,7 +33,18 @@ class HeartbeatClient:
             query += "&" if len(query) > 0 else "?"
             query += f"error={int(error_timeout.total_seconds())}"
 
-        return requests.post(f"{self.base_url}beat/{name}{query}")
+        return self.request(method="POST", url=f"{self.base_url}beat/{name}{query}")
 
     def delete_beat(self, name):
-        return requests.delete(f"{self.base_url}beat/{name}")
+        return self.request(method="DELETE", url=f"{self.base_url}beat/{name}")
+
+
+def _default_request(*, method: str, url: str) -> Any:
+    # noinspection PyUnresolvedReferences
+    import requests  # Local import, because this is an optional dependency.
+
+    return requests.request(
+        method=method,
+        url=url,
+        timeout=3,
+    ).json()

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
-    install_requires=[
-        'requests',
-    ],
+    python_requires=">=3.6",
+    install_requires=[],
 )

--- a/tests/test_with_di.py
+++ b/tests/test_with_di.py
@@ -1,0 +1,121 @@
+import unittest
+from datetime import timedelta
+from typing import Any
+
+from heartbeat_sh import HeartbeatClient
+
+
+class TestWithDi(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = HeartbeatClient(
+            subdomain="example",
+            request=self.request,
+        )
+
+    def request(self, *, method: str, url: str) -> Any:
+        if method == "DELETE" and url == "https://example.heartbeat.sh/beat/kaboom":
+            return {
+                "Name": "kaboom",
+                "Warning": 120,
+                "Error": 300,
+                "Age": 28,
+                "Status": "OK",
+                "LastBeat": "2022-05-03T06:38:02Z",
+            }
+
+        if method == "GET" and url == "https://example.heartbeat.sh/heartbeats":
+            return {
+                "Heartbeats": [
+                    {
+                        "Name": "foo",
+                        "Warning": 7200,
+                        "Error": 86400,
+                        "Age": 1408,
+                        "Status": "OK",
+                        "LastBeat": "2022-05-03T06:15:02Z",
+                    },
+                    {
+                        "Name": "bar",
+                        "Warning": 7200,
+                        "Error": 86400,
+                        "Age": 1407,
+                        "Status": "OK",
+                        "LastBeat": "2022-05-03T06:15:03Z",
+                    },
+                ]
+            }
+
+        if (
+            method == "POST"
+            and url
+            == "https://example.heartbeat.sh/beat/kaboom?warning=93600&error=172800"
+        ):
+            return {
+                "Name": "kaboom",
+                "Warning": 93600,
+                "Error": 172800,
+                "Age": 0,
+                "Status": "OK",
+                "LastBeat": "2022-05-03T06:40:48.420356888Z",
+            }
+
+        raise NotImplementedError(
+            f"TODO: Implement mock response for `{method} {url}`."
+        )
+
+    def test_get_beats(self):
+        self.assertEqual(
+            [
+                {
+                    "Name": "foo",
+                    "Warning": 7200,
+                    "Error": 86400,
+                    "Age": 1408,
+                    "Status": "OK",
+                    "LastBeat": "2022-05-03T06:15:02Z",
+                },
+                {
+                    "Name": "bar",
+                    "Warning": 7200,
+                    "Error": 86400,
+                    "Age": 1407,
+                    "Status": "OK",
+                    "LastBeat": "2022-05-03T06:15:03Z",
+                },
+            ],
+            self.client.get_beats(),
+        )
+
+    def test_send_beat(self):
+        self.assertEqual(
+            {
+                "Name": "kaboom",
+                "Warning": 93600,
+                "Error": 172800,
+                "Age": 0,
+                "Status": "OK",
+                "LastBeat": "2022-05-03T06:40:48.420356888Z",
+            },
+            self.client.send_beat(
+                name="kaboom",
+                warning_timeout=timedelta(days=1, hours=2),
+                error_timeout=timedelta(days=2),
+            ),
+        )
+
+    def test_delete_beat(self):
+        self.assertEqual(
+            {
+                "Name": "kaboom",
+                "Warning": 120,
+                "Error": 300,
+                "Age": 28,
+                "Status": "OK",
+                "LastBeat": "2022-05-03T06:38:02Z",
+            },
+            self.client.delete_beat(name="kaboom"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_with_requests.py
+++ b/tests/test_with_requests.py
@@ -4,9 +4,11 @@ from datetime import timedelta
 from heartbeat_sh import HeartbeatClient
 
 
-class TestSend(unittest.TestCase):
+class TestWithRequests(unittest.TestCase):
     def test_example(self):
-        HeartbeatClient("example").send_beat("example:python", timedelta(days=1, hours=2), timedelta(days=2))
+        HeartbeatClient("example").send_beat(
+            "example:python", timedelta(days=1, hours=2), timedelta(days=2)
+        )
 
     def test_get(self):
         HeartbeatClient("example").get_beats()


### PR DESCRIPTION
- Use Dependency Injection to allow the user to use any request back end they like by injecting a request function.
- Fall back to using the `requests` library (with a local import so that we don't have to depend on `requests`).
- Default request timeout is now 3 seconds.
- Updated README.md
- Added unit tests using DI.

Closes #4 